### PR TITLE
Refactor header icons

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -19,10 +19,6 @@
 </head>
 
 <body ng-app="HomeCooked">
-<ion-nav-bar class="nav-title-slide-ios7 bar-light">
-  <ion-nav-back-button class="button-icon ion-arrow-left-c">
-  </ion-nav-back-button>
-</ion-nav-bar>
 
 <ion-nav-view></ion-nav-view>
 

--- a/app/scripts/menu.controller.js
+++ b/app/scripts/menu.controller.js
@@ -1,6 +1,6 @@
 'use strict';
-var MenuCtrl = ['$rootScope', '$state', '$ionicPopup', 'LoginService', 'ChefService', '_',
-  function($rootScope, $state, $ionicPopup, LoginService, ChefService, _) {
+var MenuCtrl = ['$rootScope', '$state', '$ionicPopup', '$ionicHistory', 'LoginService', 'ChefService', '_',
+  function($rootScope, $state, $ionicPopup, $ionicHistory, LoginService, ChefService, _) {
     var that = this;
     var homePath = 'app.main';
 
@@ -87,6 +87,10 @@ var MenuCtrl = ['$rootScope', '$state', '$ionicPopup', 'LoginService', 'ChefServ
 
     that.go = function(path) {
       $state.go(path);
+
+      $ionicHistory.nextViewOptions({
+        historyRoot: true
+      });
     };
     $rootScope.$on('$stateChangeStart', onStateChanged);
 

--- a/app/templates/bio.html
+++ b/app/templates/bio.html
@@ -1,7 +1,4 @@
 <ion-view title="My Bio">
-  <ion-nav-buttons side="left">
-    <button menu-toggle="left"class="button button-icon icon ion-navicon"></button>
-  </ion-nav-buttons>
   <ion-content class="has-header">
     View and edit chef bio
 	</div>

--- a/app/templates/buyer.html
+++ b/app/templates/buyer.html
@@ -1,7 +1,4 @@
 <ion-view title="Find local chefs" ng-controller="SearchCtrl as ctrl">
-  <ion-nav-buttons side="left">
-    <button menu-toggle="left"class="button button-icon icon ion-navicon"></button>
-  </ion-nav-buttons>
   <ion-content class="has-header">
   	<div class="list list-inset">
       <label class="item item-input padding-vertical">

--- a/app/templates/chef.html
+++ b/app/templates/chef.html
@@ -1,7 +1,4 @@
 <ion-view ng-controller="ChefCtrl as ctrl" title="Dishes I'm cooking">
-  <ion-nav-buttons side="left">
-    <button menu-toggle="left" class="button button-icon icon ion-navicon"></button>
-  </ion-nav-buttons>
   <ion-content class="has-header">
     <div class="list">
       <div class="item item-avatar" ng-repeat="batch in ctrl.batches">

--- a/app/templates/delivery.html
+++ b/app/templates/delivery.html
@@ -1,7 +1,4 @@
 <ion-view title="Delivery kits">
-  <ion-nav-buttons side="left">
-    <button menu-toggle="left"class="button button-icon icon ion-navicon"></button>
-  </ion-nav-buttons>
   <ion-content class="has-header">
     View and order delivery kits
 	</div>

--- a/app/templates/dishes.html
+++ b/app/templates/dishes.html
@@ -1,7 +1,4 @@
 <ion-view title="My Dishes" ng-controller="DishesCtrl as ctrl">
-  <ion-nav-buttons side="left">
-    <button menu-toggle="left" class="button button-icon icon ion-navicon"></button>
-  </ion-nav-buttons>
   <ion-content class="has-header">
     <ion-list>
       <div class="item item-avatar" ng-repeat="dish in ctrl.dishes">

--- a/app/templates/enroll.html
+++ b/app/templates/enroll.html
@@ -1,7 +1,4 @@
 <ion-view title="Become a chef!" ng-controller="EnrollCtrl as enroll">
-  <ion-nav-buttons side="left">
-    <button menu-toggle="left" class="button button-icon icon ion-navicon"></button>
-  </ion-nav-buttons>
   <ion-content class="has-header">
 
     <form novalidate class="list list-inset" name="enrollForm">

--- a/app/templates/menu.html
+++ b/app/templates/menu.html
@@ -1,6 +1,14 @@
-<ion-side-menus ng-controller="MenuCtrl as ctrl">
+<ion-side-menus ng-controller="MenuCtrl as ctrl" enable-menu-with-back-views="false">
   <ion-pane ion-side-menu-content>
-    <ion-nav-bar class="bar-stable nav-title-slide-ios7"></ion-nav-bar>
+    <ion-nav-bar class="bar-stable nav-title-slide-ios7">
+      <ion-nav-back-button>
+      </ion-nav-back-button>
+
+      <ion-nav-buttons side="left">
+        <button class="button button-icon button-clear ion-navicon" menu-toggle="left">
+        </button>
+      </ion-nav-buttons>
+    </ion-nav-bar>
     <ion-nav-view name="menuContent" animation="slide-left-right"></ion-nav-view>
   </ion-pane>
 

--- a/app/templates/orders.html
+++ b/app/templates/orders.html
@@ -1,7 +1,4 @@
 <ion-view title="My Order">
-  <ion-nav-buttons side="left">
-    <button menu-toggle="left" class="button button-icon icon ion-navicon"></button>
-  </ion-nav-buttons>
   <ion-content class="has-header">
     <p class="padding" align="center">
       You haven't placed any order yet.<br>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,7 +1,4 @@
 <ion-view title="Settings" ng-controller="SettingsCtrl as ctrl">
-  <ion-nav-buttons side="left">
-    <button menu-toggle="left" class="button button-icon icon ion-navicon"></button>
-  </ion-nav-buttons>
   <ion-content class="has-header">
     <div style="position: relative">
       <img ng-src="{{user.image ||'images/user.png'}}" width="120">


### PR DESCRIPTION
In this PR I cleaned the way the back button and the menu button are managed.

- ion-nav-bar was useless in index.html since it is already defined in menu.html
- ion-nav-buttons needs to be defined only one time in menu.html. No need to define it in each template.

To avoid having the back button instead of the menu button, we need to define a set of "root pages", basically all the links in the left menu are root pages. That's why we need to defined ```historyRoot: true``` when you click on a menu item. See http://ionicframework.com/docs/api/service/$ionicHistory/#nextViewOptions for more information.