### PR TITLE
Zipcode restriction

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -384,6 +384,7 @@ module.exports = function(grunt) {
           '<%= yeoman.app %>/lib/angular-ui-router/release/angular-ui-router.min.js',
           '<%= yeoman.app %>/lib/ionic/js/ionic.js',
           '<%= yeoman.app %>/lib/ionic/js/ionic-angular.min.js',
+          '<%= yeoman.app %>/lib/angular-leaflet-directive/dist/angular-leaflet-directive.min.js',
           '<%= yeoman.app %>/<%= yeoman.scripts %>/**/*.js',
           '<%= yeoman.app %>/**/*.html',
           'test/mock/**/*.js',

--- a/app/index.html
+++ b/app/index.html
@@ -57,6 +57,7 @@
 <script src="scripts/enroll.controller.js"></script>
 <script src="scripts/search.controller.js"></script>
 <script src="scripts/chef.controller.js"></script>
+<script src="scripts/zipcoderestriction.controller.js"></script>
 <script src="scripts/dishes.controller.js"></script>
 <!-- endbuild -->
 </body>

--- a/app/index.html
+++ b/app/index.html
@@ -10,6 +10,8 @@
   <!-- <link rel="stylesheet" href="vendor/some.contrib.css"> -->
   <!-- bower:css -->
   <link rel="stylesheet" href="lib/ionic/css/ionic.css" />
+  <link rel="stylesheet" href="lib/leaflet/dist/leaflet.css" />
+  <link rel="stylesheet" href="lib/font-awesome/css/font-awesome.css" />
   <!-- endbower -->
   <!-- endbuild -->
 
@@ -33,6 +35,9 @@
 <script src="lib/ionic/js/ionic-angular.js"></script>
 <script src="lib/lodash/lodash.js"></script>
 <script src="lib/angular-mocks/angular-mocks.js"></script>
+<script src="lib/leaflet/dist/leaflet.js"></script>
+<script src="lib/leaflet/dist/leaflet-src.js"></script>
+<script src="lib/angular-leaflet-directive/dist/angular-leaflet-directive.js"></script>
 <!-- endbower -->
 <!-- endbuild -->
 

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var HomeCooked = angular.module('HomeCooked', ['ionic', 'ngAnimate', 'config', 'HomeCooked.controllers']);
+var HomeCooked = angular.module('HomeCooked', ['ionic', 'ngAnimate', 'config', 'HomeCooked.controllers', 'leaflet-directive']);
 
 angular.module('HomeCooked.controllers', ['HomeCooked.services']);
 angular.module('HomeCooked.services', []);

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -120,6 +120,11 @@ HomeCooked
         url: '/zipcode-validation',
         templateUrl: 'templates/zipcode/form.html',
         controller: 'ZipCodeRestrictionCtrl as vm'
+      })
+      .state('zipcode-unavailable', {
+        url: '/zipcode-unavailable/:zipcode',
+        templateUrl: 'templates/zipcode/unavailable.html',
+        controller: 'ZipCodeRestrictionCtrl as vm'
       });
     // if none of the above states are matched, use this as the fallback
     $urlRouterProvider.otherwise(function($injector) {

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -115,6 +115,11 @@ HomeCooked
             templateUrl: 'templates/not-found.html'
           }
         }
+      })
+      .state('zipcode-validation', {
+        url: '/zipcode-validation',
+        templateUrl: 'templates/zipcode/form.html',
+        controller: 'ZipCodeRestrictionCtrl as vm'
       });
     // if none of the above states are matched, use this as the fallback
     $urlRouterProvider.otherwise('/buyer');

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -122,7 +122,18 @@ HomeCooked
         controller: 'ZipCodeRestrictionCtrl as vm'
       });
     // if none of the above states are matched, use this as the fallback
-    $urlRouterProvider.otherwise('/buyer');
+    $urlRouterProvider.otherwise(function($injector) {
+      var $state = $injector.get('$state');
+      var LoginService = $injector.get('LoginService');
+      var nextState = 'app.not-found';
+      if (!LoginService.getUser()) {
+        nextState = 'zipcode-validation';
+      }
+      else if ($state.current.name === '') {
+        nextState = 'app.buyer';
+      }
+      $state.go(nextState);
+    });
   })
   .run(function($ionicPlatform) {
     $ionicPlatform.ready(function() {

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -7,10 +7,10 @@ angular.module('HomeCooked.services', []);
 
 HomeCooked
   .constant('_', window._) //lodash
-  .config(function($httpProvider) {
+  .config(function ($httpProvider) {
     $httpProvider.interceptors.push('AuthInterceptor');
   })
-  .config(function($stateProvider, $urlRouterProvider, $compileProvider, ENV) {
+  .config(function ($stateProvider, $urlRouterProvider, $compileProvider, ENV) {
 
     $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|ftp|mailto|geo|maps|market|file|itms|itms-apps):/);
 
@@ -127,12 +127,13 @@ HomeCooked
         controller: 'ZipCodeRestrictionCtrl as vm'
       });
     // if none of the above states are matched, use this as the fallback
-    $urlRouterProvider.otherwise(function($injector) {
+    $urlRouterProvider.otherwise(function ($injector) {
       var $state = $injector.get('$state');
       var LoginService = $injector.get('LoginService');
+      var CacheService = $injector.get('CacheService');
       var nextState = 'app.not-found';
       if (!LoginService.getUser()) {
-        nextState = 'zipcode-validation';
+        nextState = CacheService.getCache('hcvalidzipcode') ? 'app.buyer' : 'zipcode-validation';
       }
       else if ($state.current.name === '') {
         nextState = 'app.buyer';
@@ -140,8 +141,8 @@ HomeCooked
       $state.go(nextState);
     });
   })
-  .run(function($ionicPlatform) {
-    $ionicPlatform.ready(function() {
+  .run(function ($ionicPlatform) {
+    $ionicPlatform.ready(function () {
       // Hide the accessory b ar by default (remove this to show the accessory bar above the keyboard
       // for form inputs)
       if (window.cordova && window.cordova.plugins.Keyboard) {

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -130,10 +130,10 @@ HomeCooked
     $urlRouterProvider.otherwise(function ($injector) {
       var $state = $injector.get('$state');
       var LoginService = $injector.get('LoginService');
-      var CacheService = $injector.get('CacheService');
-      var nextState = 'app.not-found';
-      if (!LoginService.getUser()) {
-        nextState = CacheService.getCache('hcvalidzipcode') ? 'app.buyer' : 'zipcode-validation';
+      var nextState = 'app.not-found',
+          user = LoginService.getUser();
+      if (!user.isLoggedIn) {
+        nextState = user.zipcode ? 'app.buyer' : 'zipcode-validation';
       }
       else if ($state.current.name === '') {
         nextState = 'app.buyer';

--- a/app/scripts/auth-interceptor.service.js
+++ b/app/scripts/auth-interceptor.service.js
@@ -13,8 +13,7 @@ angular.module('HomeCooked.services')
         },
         response: function (response) {
           if (response.status === 401) {
-            CacheService.setCache('hccredential');
-            CacheService.setCache('hcuser');
+            CacheService.emptyCache();
           }
           return response || $q.when(response);
         }

--- a/app/scripts/auth-interceptor.service.js
+++ b/app/scripts/auth-interceptor.service.js
@@ -5,7 +5,7 @@ angular.module('HomeCooked.services')
       return {
         request: function (config) {
           config.headers = config.headers || {};
-          var credential = CacheService.getCache('hccredential');
+          var credential = CacheService.getValue('credential');
           if (credential) {
             config.headers.Authorization = credential.token_type + ' ' + credential.access_token;
           }
@@ -13,7 +13,7 @@ angular.module('HomeCooked.services')
         },
         response: function (response) {
           if (response.status === 401) {
-            CacheService.emptyCache();
+            CacheService.invalidateCache();
           }
           return response || $q.when(response);
         }

--- a/app/scripts/cache.service.js
+++ b/app/scripts/cache.service.js
@@ -1,46 +1,57 @@
 'use strict';
 (function () {
   angular.module('HomeCooked.services').factory('CacheService', CacheService);
-  CacheService.$inject = ['$window'];
-  function CacheService($window) {
-    var cacheId = 'hcdata',
-      cacheData = getCacheData();
+  CacheService.$inject = ['$window', '_'];
+  function CacheService($window, _) {
+    var cacheId = 'hc-cache',
+      cache = readCache(cacheId) || {};
 
     return {
-      getCache: getCache,
-      setCache: setCache,
-      emptyCache: emptyCache
+      getValue: getValue,
+      setValue: setValue,
+      invalidateCache: invalidateCache
     };
 
-    function getCache(key) {
-      return cacheData[key];
+    function getValue(key) {
+      return cache[key];
     }
 
-    function setCache(key, value) {
-      cacheData[key] = value;
-      if (typeof value === 'undefined') {
-        delete cacheData[key];
-      }
-      saveCacheData();
+    function setValue(keyValues) {
+      _.forEach(keyValues, function (value, key) {
+        cache[key] = value;
+        if (typeof value === 'undefined') {
+          delete cache[key];
+        }
+      });
+      saveCache(cacheId, cache);
     }
 
-    function emptyCache() {
-      cacheData = {};
-      saveCacheData();
+    function invalidateCache() {
+      saveCache(cacheId);
+      cache = {};
     }
 
-    function getCacheData() {
+    function readCache(key) {
       if (!$window.localStorage) {
-        return {};
+        return;
       }
-      var serializedCache = $window.localStorage.getItem(cacheId);
-      return JSON.parse(serializedCache) || {};
+      var storedCache = $window.localStorage.getItem(key);
+      if (storedCache) {
+        return JSON.parse(storedCache);
+      }
     }
 
-    function saveCacheData() {
-      if ($window.localStorage) {
-        $window.localStorage.setItem(cacheId, JSON.stringify(cacheData));
+    function saveCache(key, data) {
+      if (!$window.localStorage) {
+        return;
+      }
+      if (!data) {
+        $window.localStorage.removeItem(key);
+      }
+      else {
+        $window.localStorage.setItem(key, JSON.stringify(data));
       }
     }
   }
-})();
+})
+();

--- a/app/scripts/cache.service.js
+++ b/app/scripts/cache.service.js
@@ -1,22 +1,22 @@
 'use strict';
 angular.module('HomeCooked.services')
   .factory('CacheService', ['$window', '_',
-    function($window, _) {
+    function ($window, _) {
       var self = this;
 
-      self.getCache = function(key) {
+      self.getCache = function (key) {
         if ($window.localStorage) {
           var serializedCache = $window.localStorage.getItem(key);
           return deserializeCache(serializedCache);
         }
       };
 
-      self.setCache = function(key, value) {
+      self.setCache = function (key, value) {
         if (!$window.localStorage) {
           return;
         }
 
-        if (_.isEmpty(value)) {
+        if (typeof value === 'undefined') {
           $window.localStorage.removeItem(key);
         }
         else {
@@ -27,7 +27,7 @@ angular.module('HomeCooked.services')
         }
       };
 
-      var deserializeCache = function(json) {
+      var deserializeCache = function (json) {
         try {
           return JSON.parse(json);
         }

--- a/app/scripts/cache.service.js
+++ b/app/scripts/cache.service.js
@@ -1,41 +1,46 @@
 'use strict';
-angular.module('HomeCooked.services')
-  .factory('CacheService', ['$window',
-    function ($window) {
-      var self = this;
+(function () {
+  angular.module('HomeCooked.services').factory('CacheService', CacheService);
+  CacheService.$inject = ['$window'];
+  function CacheService($window) {
+    var cacheId = 'hcdata',
+      cacheData = getCacheData();
 
-      self.getCache = function (key) {
-        if ($window.localStorage) {
-          var serializedCache = $window.localStorage.getItem(key);
-          return deserializeCache(serializedCache);
-        }
-      };
+    return {
+      getCache: getCache,
+      setCache: setCache,
+      emptyCache: emptyCache
+    };
 
-      self.setCache = function (key, value) {
-        if (!$window.localStorage) {
-          return;
-        }
+    function getCache(key) {
+      return cacheData[key];
+    }
 
-        if (typeof value === 'undefined') {
-          $window.localStorage.removeItem(key);
-        }
-        else {
-          if (typeof value === 'object') {
-            value = JSON.stringify(value);
-          }
-          $window.localStorage.setItem(key, value);
-        }
-      };
+    function setCache(key, value) {
+      cacheData[key] = value;
+      if (typeof value === 'undefined') {
+        delete cacheData[key];
+      }
+      saveCacheData();
+    }
 
-      var deserializeCache = function (json) {
-        try {
-          return JSON.parse(json);
-        }
-        catch (e) {
-          return json;
-        }
-      };
+    function emptyCache() {
+      cacheData = {};
+      saveCacheData();
+    }
 
-      return self;
-    }]
-);
+    function getCacheData() {
+      if (!$window.localStorage) {
+        return {};
+      }
+      var serializedCache = $window.localStorage.getItem(cacheId);
+      return JSON.parse(serializedCache) || {};
+    }
+
+    function saveCacheData() {
+      if ($window.localStorage) {
+        $window.localStorage.setItem(cacheId, JSON.stringify(cacheData));
+      }
+    }
+  }
+})();

--- a/app/scripts/cache.service.js
+++ b/app/scripts/cache.service.js
@@ -1,7 +1,7 @@
 'use strict';
 angular.module('HomeCooked.services')
-  .factory('CacheService', ['$window', '_',
-    function ($window, _) {
+  .factory('CacheService', ['$window',
+    function ($window) {
       var self = this;
 
       self.getCache = function (key) {

--- a/app/scripts/chef.service.js
+++ b/app/scripts/chef.service.js
@@ -1,53 +1,47 @@
 'use strict';
 angular.module('HomeCooked.services')
   .factory('ChefService', ['$q', '$http', '$timeout', 'ENV', '_',
-    function($q, $http, $timeout, ENV, _) {
+    function ($q, $http, $timeout, ENV, _) {
       var baseUrl = ENV.BASE_URL + '/api/v1/';
 
       var ordersReady;
 
-      var handleResponses = function(httpPromise) {
-        var deferred = $q.defer();
-        httpPromise
-          .then(function(response) {
-            deferred.resolve(response.data);
-          })
-          .catch(function(error) {
-            deferred.reject(error.data);
-          });
-        return deferred.promise;
+      var handleResponses = function (httpPromise) {
+        return httpPromise.then(function (response) {
+          return response.data;
+        });
       };
-      var wait = function(ms) {
-        return $timeout(function() {
+      var wait = function (ms) {
+        return $timeout(function () {
         }, ms || 0);
       };
 
-      var getOrders = function() {
+      var getOrders = function () {
         ordersReady = ordersReady || handleResponses($http.get('mock/orders.json'));
         return ordersReady;
       };
 
-      var getBatches = function() {
+      var getBatches = function () {
         return handleResponses($http.get(baseUrl + 'batches/'));
       };
 
-      var getDishes = function() {
+      var getDishes = function () {
         return handleResponses($http.get(baseUrl + 'dishes/'));
       };
 
-      var addDish = function(dish) {
+      var addDish = function (dish) {
         return handleResponses($http.post(baseUrl + 'dishes/', dish)).then(getDishes);
       };
 
 
-      var addBatch = function(batch) {
+      var addBatch = function (batch) {
         return handleResponses($http.post(baseUrl + 'batches/', batch)).then(getBatches);
       };
 
-      var removeBatchAvailablePortions = function(batch) {
+      var removeBatchAvailablePortions = function (batch) {
         //FIXME remove this and call the service
         return $q.all([getBatches(), wait(300)])
-          .then(function(values) {
+          .then(function (values) {
             var batches = values[0];
             var i = _.findIndex(batches, {'dishId': batch.dishId, 'price': batch.price});
             if (i >= 0) {
@@ -65,7 +59,7 @@ angular.module('HomeCooked.services')
         //return handleResponses($http.delete(baseUrl + 'batches/' + batch.id)).then(getBatches);
       };
 
-      var getChefData = function() {
+      var getChefData = function () {
         //TODO read this from server!!
         var chefData = {
           maxPrice: 100,
@@ -75,7 +69,7 @@ angular.module('HomeCooked.services')
         return $q.when(chefData);
       };
 
-      var getChefInfo = function(chefId) {
+      var getChefInfo = function (chefId) {
         return handleResponses($http.get(baseUrl + 'chefs/' + chefId + '/'));
       };
 

--- a/app/scripts/login.service.js
+++ b/app/scripts/login.service.js
@@ -1,79 +1,100 @@
 'use strict';
-angular.module('HomeCooked.services')
-  .factory('LoginService', ['$q', '$http', '$window', 'ENV', 'CacheService',
-    function($q, $http, $window, ENV, CacheService) {
-      var self = this;
-      var user = CacheService.getCache('hcuser');
+(function () {
+  angular.module('HomeCooked.services').factory('LoginService', LoginService);
 
-      var homeCookedLogin = function(accessToken, provider) {
-        var deferred = $q.defer();
-        $http.post(ENV.BASE_URL + '/connect/', {
-          'access_token': accessToken,
-          'client_id': ENV.CLIENT_ID,
-          'provider': provider
+  LoginService.$inject = ['$q', '$http', 'ENV', 'CacheService'];
+  function LoginService($q, $http, ENV, CacheService) {
+    var user = getUserFromCache();
+
+    return {
+      login: login,
+      logout: logout,
+      getUser: getUser,
+      setUserZipCode: setUserZipCode,
+      becomeChef: becomeChef
+    };
+
+
+    function login(type) {
+      return getAccessToken(type).then(function (accessToken) {
+        return homeCookedLogin(accessToken, type);
+      });
+    }
+
+    function logout() {
+      updateCache();
+    }
+
+    function getUser() {
+      return user;
+    }
+
+    function setUserZipCode(zipcode) {
+      user.zipcode = zipcode;
+      CacheService.setCache('hcuser', user);
+    }
+
+    function becomeChef(chefInfo) {
+      //FIXME remove this and use real service
+      return $q.when('OK', chefInfo);
+
+      //var deferred = $q.defer();
+      //$http.post(ENV.BASE_URL + '/enroll/', chefInfo)
+      //  .success(deferred.resolve)
+      //  .error(function (data) {
+      //    deferred.reject(JSON.stringify(data));
+      //  });
+      //return deferred.promise;
+    }
+
+    function getUserFromCache() {
+      return CacheService.getCache('hcuser') || {};
+    }
+
+    function homeCookedLogin(accessToken, provider) {
+      var deferred = $q.defer();
+      $http.post(ENV.BASE_URL + '/connect/', {
+        'access_token': accessToken,
+        'client_id': ENV.CLIENT_ID,
+        'provider': provider
+      })
+        .success(function (data) {
+          // TODO this should come from the server
+          data.user.zipcode = user.zipcode;
+          data.user.isLoggedIn = true;
+          updateCache(data.credential, data.user);
+          deferred.resolve(user);
         })
-          .success(function(data) {
-            _updateLogin(data.credential, data.user);
-            deferred.resolve(self.getUser());
-          })
-          .error(function loginFail(data) {
-            _updateLogin();
-            deferred.reject(data);
-          });
-        return deferred.promise;
-      };
-
-      var getAccessToken = function(provider) {
-        var deferred = $q.defer();
-        if (provider === 'facebook') {
-          window.openFB.login(function(response) {
-            if (response && response.authResponse && response.authResponse.token) {
-              deferred.resolve(response.authResponse.token);
-            }
-            else {
-              deferred.reject('not connected');
-            }
-          }, {scope: 'email'});
-        }
-        else {
-          deferred.reject('not supported');
-        }
-        return deferred.promise;
-      };
-
-      var _updateLogin = function(credential, newUser) {
-        CacheService.setCache('hccredential', credential);
-        CacheService.setCache('hcuser', newUser);
-        user = newUser;
-      };
-
-      self.login = function(type) {
-        return getAccessToken(type).then(function(accessToken) {
-          return homeCookedLogin(accessToken, type);
+        .error(function loginFail(data) {
+          updateCache();
+          deferred.reject(data);
         });
-      };
+      return deferred.promise;
+    }
 
-      self.logout = function() {
-        _updateLogin();
-        CacheService.setCache('hcvalidzipcode');
-      };
+    function getAccessToken(provider) {
+      var deferred = $q.defer();
+      if (provider === 'facebook') {
+        window.openFB.login(function (response) {
+          if (response && response.authResponse && response.authResponse.token) {
+            deferred.resolve(response.authResponse.token);
+          }
+          else {
+            deferred.reject('not connected');
+          }
+        }, {scope: 'email'});
+      }
+      else {
+        deferred.reject('not supported');
+      }
+      return deferred.promise;
+    }
 
-      self.getUser = function() {
-        return user;
-      };
-
-      self.becomeChef = function(chefInfo) {
-        //FIXME remove this and use real service
-        return $q.when('OK', chefInfo);
-
-        //var deferred = $q.defer();
-        //$http.post(ENV.BASE_URL + '/enroll/', chefInfo)
-        //  .success(deferred.resolve)
-        //  .error(function (data) {
-        //    deferred.reject(JSON.stringify(data));
-        //  });
-        //return deferred.promise;
-      };
-      return self;
-    }]
-);
+    function updateCache(credential, newUser) {
+      newUser = newUser || {};
+      CacheService.setCache('hccredential', credential);
+      CacheService.setCache('hcuser', newUser);
+      user = newUser;
+    }
+  }
+})();

--- a/app/scripts/login.service.js
+++ b/app/scripts/login.service.js
@@ -55,6 +55,7 @@ angular.module('HomeCooked.services')
 
       self.logout = function() {
         _updateLogin();
+        CacheService.setCache('hcvalidzipcode');
       };
 
       self.getUser = function() {

--- a/app/scripts/login.service.js
+++ b/app/scripts/login.service.js
@@ -22,7 +22,7 @@
     }
 
     function logout() {
-      updateCache();
+      invalidateCache();
     }
 
     function getUser() {
@@ -31,7 +31,7 @@
 
     function setUserZipCode(zipcode) {
       user.zipcode = zipcode;
-      CacheService.setCache('hcuser', user);
+      CacheService.setValue({user: user});
     }
 
     function becomeChef(chefInfo) {
@@ -48,7 +48,7 @@
     }
 
     function getUserFromCache() {
-      return CacheService.getCache('hcuser') || {};
+      return CacheService.getValue('user') || {};
     }
 
     function homeCookedLogin(accessToken, provider) {
@@ -62,11 +62,15 @@
           // TODO this should come from the server
           data.user.zipcode = user.zipcode;
           data.user.isLoggedIn = true;
-          updateCache(data.credential, data.user);
+          CacheService.setValue({
+            credential: data.credential,
+            user: data.user
+          });
+          user = data.user;
           deferred.resolve(user);
         })
         .error(function loginFail(data) {
-          updateCache();
+          invalidateCache();
           deferred.reject(data);
         });
       return deferred.promise;
@@ -90,11 +94,9 @@
       return deferred.promise;
     }
 
-    function updateCache(credential, newUser) {
-      newUser = newUser || {};
-      CacheService.setCache('hccredential', credential);
-      CacheService.setCache('hcuser', newUser);
-      user = newUser;
+    function invalidateCache() {
+      CacheService.invalidateCache();
+      user = {};
     }
   }
 })();

--- a/app/scripts/menu.controller.js
+++ b/app/scripts/menu.controller.js
@@ -5,9 +5,9 @@
         .module('HomeCooked.controllers')
         .controller('MenuCtrl', MenuCtrl);
 
-    MenuCtrl.$inject = ['$rootScope', '$scope', '$state', '$ionicHistory', '$ionicModal', 'LoginService', 'ChefService', '_'];
+    MenuCtrl.$inject = ['$rootScope', '$scope', '$state', '$ionicHistory', '$ionicModal', 'LoginService', 'ChefService', 'CacheService', '_'];
 
-    function MenuCtrl($rootScope, $scope, $state, $ionicHistory, $ionicModal, LoginService, ChefService, _) {
+    function MenuCtrl($rootScope, $scope, $state, $ionicHistory, $ionicModal, LoginService, ChefService, CacheService, _) {
 
         var vm = this;
         vm.logout = logout;
@@ -90,12 +90,14 @@
                 }
                 return;
             }
-            if (!vm.isUserLoggedIn && path !== 'app.buyer') {
+            var validZipCode = CacheService.getCache('hcvalidzipcode'),
+                redirectPath = validZipCode ? 'app.buyer' : 'zipcode-validation';
+            if (!vm.isUserLoggedIn && path !== redirectPath) {
                 if (event) {
                     event.preventDefault();
                 }
-                go('app.buyer');
-                return login();
+                go(redirectPath);
+                return;
             }
 
             vm.chefMode = chefMode;

--- a/app/scripts/menu.controller.js
+++ b/app/scripts/menu.controller.js
@@ -50,19 +50,16 @@
 
     $scope.$watch(function () {
       return user.isLoggedIn;
-    }, function (isLoggedIn) {
-      vm.isUserLoggedIn = isLoggedIn === true;
+    }, init);
+
+    function init() {
+      vm.isUserLoggedIn = user.isLoggedIn === true;
+      vm.userFirstName = user.first_name || '';
       vm.isChef = user.isChef;
       if (user.isChef && buyerLinks[buyerLinks.length - 1].path === 'app.enroll') {
         buyerLinks.pop();
       }
       updateStateIfNeeded($state.current);
-    });
-
-    function init() {
-      vm.isUserLoggedIn = user.isLoggedIn;
-      vm.userFirstName = user.first_name || '';
-      vm.isChef = user.isChef;
     }
 
     function getCorrectPath(path) {

--- a/app/scripts/menu.controller.js
+++ b/app/scripts/menu.controller.js
@@ -53,6 +53,9 @@
     }, function (isLoggedIn) {
       vm.isUserLoggedIn = isLoggedIn === true;
       vm.isChef = user.isChef;
+      if (user.isChef && buyerLinks[buyerLinks.length - 1].path === 'app.enroll') {
+        buyerLinks.pop();
+      }
       updateStateIfNeeded($state.current);
     });
 

--- a/app/scripts/menu.controller.js
+++ b/app/scripts/menu.controller.js
@@ -1,142 +1,138 @@
-(function() {
-    'use strict';
+(function () {
+  'use strict';
 
-    angular
-        .module('HomeCooked.controllers')
-        .controller('MenuCtrl', MenuCtrl);
+  angular
+    .module('HomeCooked.controllers')
+    .controller('MenuCtrl', MenuCtrl);
 
-    MenuCtrl.$inject = ['$rootScope', '$scope', '$state', '$ionicHistory', '$ionicModal', 'LoginService', 'ChefService', '_'];
+  MenuCtrl.$inject = ['$rootScope', '$scope', '$state', '$ionicHistory', '$ionicModal', 'LoginService', '_'];
 
-    function MenuCtrl($rootScope, $scope, $state, $ionicHistory, $ionicModal, LoginService, ChefService, _) {
+  function MenuCtrl($rootScope, $scope, $state, $ionicHistory, $ionicModal, LoginService, _) {
 
-        var vm = this;
-        vm.login = login;
-        vm.switchView = switchView;
-        vm.go = go;
+    var vm = this;
+    vm.login = login;
+    vm.switchView = switchView;
+    vm.go = go;
 
-        var chefLinks = [{
-            name: 'Orders',
-            path: 'app.seller'
-        }, {
-            name: 'My dishes',
-            path: 'app.dishes'
-        }, {
-            name: 'Edit Bio',
-            path: 'app.bio'
-        }, {
-            name: 'Get more delivery kits',
-            path: 'app.delivery'
-        }];
+    var chefLinks = [{
+      name: 'Orders',
+      path: 'app.seller'
+    }, {
+      name: 'My dishes',
+      path: 'app.dishes'
+    }, {
+      name: 'Edit Bio',
+      path: 'app.bio'
+    }, {
+      name: 'Get more delivery kits',
+      path: 'app.delivery'
+    }];
 
-        var buyerLinks = [{
-            name: 'Find local chefs',
-            path: 'app.buyer'
-        }, {
-            name: 'My Order',
-            path: 'app.orders'
-        }, {
-            name: 'Payment methods',
-            path: 'app.settings'
-        }, {
-            name: 'Become a chef!',
-            path: 'app.enroll'
-        }];
+    var buyerLinks = [{
+      name: 'Find local chefs',
+      path: 'app.buyer'
+    }, {
+      name: 'My Order',
+      path: 'app.orders'
+    }, {
+      name: 'Payment methods',
+      path: 'app.settings'
+    }, {
+      name: 'Become a chef!',
+      path: 'app.enroll'
+    }];
 
+    // will be same instance during all the session
+    var user = LoginService.getUser();
 
-        init();
-        $rootScope.$on('$stateChangeStart', onStateChanged);
+    init();
+    $scope.$on('$stateChangeStart', onStateChanged);
 
-        function init() {
-            var user = LoginService.getUser();
-            vm.isUserLoggedIn = user.isLoggedIn;
-            vm.userFirstName = user.first_name || '';
-            vm.isChef = undefined;
-            vm.selectedPath = null;
-            if (user.id) {
-                ChefService.getChefInfo(user.id)
-                    .then(function() {
-                        vm.isChef = true;
-                        var enroll = buyerLinks.pop();
-                        if ($state.current.name === enroll.path) {
-                            vm.go(buyerLinks[0].path);
-                        }
-                    })
-                    .catch (function() {
-                        vm.isChef = false;
-                        if (_.some(chefLinks, {
-                            path: $state.current.name
-                        })) {
-                            vm.go(buyerLinks[0].path);
-                        } else {
-                            vm.links = buyerLinks;
-                        }
-                    });
-            }
-            onStateChanged(null, $state.current);
-        }
+    $scope.$watch(function () {
+      return user.isLoggedIn;
+    }, function (isLoggedIn) {
+      vm.isUserLoggedIn = isLoggedIn === true;
+      vm.isChef = user.isChef;
+      updateStateIfNeeded($state.current);
+    });
 
-        function onStateChanged(event, toState) {
-            var path = toState.name;
-
-            var chefMode = _.some(chefLinks, {
-                path: path
-            });
-            if ((vm.isChef === false && chefMode) || (vm.isChef && path === 'app.enroll')) {
-                if (event) {
-                    event.preventDefault();
-                } else {
-                    vm.go(buyerLinks[0].path);
-                }
-                return;
-            }
-            var zipcode = LoginService.getUser().zipcode,
-                redirectPath = !!zipcode ? 'app.buyer' : 'zipcode-validation';
-            if (!vm.isUserLoggedIn && path !== redirectPath) {
-                if (event) {
-                    event.preventDefault();
-                }
-                go(redirectPath);
-                return;
-            }
-
-            vm.chefMode = chefMode;
-            vm.links = vm.chefMode ? chefLinks : buyerLinks;
-            vm.selectedPath = path;
-        }
-
-        function switchView() {
-            var path = vm.chefMode ? chefLinks[0].path : buyerLinks[0].path;
-            vm.go(path);
-        }
-
-        function go(path) {
-            $ionicHistory.nextViewOptions({
-                historyRoot: true,
-                disableAnimate: true
-            });
-            $state.go(path);
-        }
-
-        function login() {
-            if (!vm.modal) {
-                var modalScope = $rootScope.$new();
-                $ionicModal.fromTemplateUrl('templates/signup/signup.html', {
-                    animation: 'slide-in-up',
-                    scope: modalScope
-                }).then(function(modal) {
-                    vm.modal = modal;
-                    vm.modal.show();
-                });
-                modalScope.closeModal = function() {
-                    vm.modal.hide();
-                    init();
-                };
-                $scope.$on('$destroy', function() {
-                    vm.modal.remove();
-                });
-            } else {
-                vm.modal.show();
-            }
-        }
+    function init() {
+      vm.isUserLoggedIn = user.isLoggedIn;
+      vm.userFirstName = user.first_name || '';
+      vm.isChef = user.isChef;
     }
+
+    function getCorrectPath(path) {
+      if (vm.isChef && path === 'app.enroll') {
+        return chefLinks[0].path;
+      }
+
+      if (!user.isLoggedIn && !user.zipcode) {
+        return 'zipcode-validation';
+      }
+
+      var chefMode = _.some(chefLinks, {path: path});
+      if ((vm.isChef === false && chefMode) || (!user.isLoggedIn && user.zipcode)) {
+        return 'app.buyer';
+      }
+
+      return path;
+    }
+
+    function updateStateIfNeeded(state) {
+      var path = state.name;
+      var correctPath = getCorrectPath(path);
+      if (path !== correctPath) {
+        $state.go(correctPath);
+        return true;
+      }
+      _.forEach(chefLinks.concat(buyerLinks), function (link) {
+        link.selected = link.path === path;
+      });
+      vm.chefMode = _.some(chefLinks, 'selected');
+      vm.links = vm.chefMode ? chefLinks : buyerLinks;
+      return false;
+    }
+
+    function onStateChanged(event, toState) {
+      if (updateStateIfNeeded(toState)) {
+        event.preventDefault();
+      }
+    }
+
+    function switchView() {
+      var path = vm.chefMode ? chefLinks[0].path : buyerLinks[0].path;
+      vm.go(path);
+    }
+
+    function go(path) {
+      $ionicHistory.nextViewOptions({
+        historyRoot: true,
+        disableAnimate: true
+      });
+      $state.go(path);
+    }
+
+    function login() {
+      if (!vm.modal) {
+        var modalScope = $rootScope.$new();
+        $ionicModal.fromTemplateUrl('templates/signup/signup.html', {
+          animation: 'slide-in-up',
+          scope: modalScope
+        }).then(function (modal) {
+          vm.modal = modal;
+          vm.modal.show();
+        });
+        modalScope.closeModal = function () {
+          vm.modal.hide();
+          init();
+        };
+        $scope.$on('$destroy', function () {
+          vm.modal.remove();
+        });
+      } else {
+        vm.modal.show();
+      }
+    }
+  }
 })();

--- a/app/scripts/menu.controller.js
+++ b/app/scripts/menu.controller.js
@@ -5,9 +5,9 @@
         .module('HomeCooked.controllers')
         .controller('MenuCtrl', MenuCtrl);
 
-    MenuCtrl.$inject = ['$rootScope', '$scope', '$state', '$ionicHistory', '$ionicModal', 'LoginService', 'ChefService', 'CacheService', '_'];
+    MenuCtrl.$inject = ['$rootScope', '$scope', '$state', '$ionicHistory', '$ionicModal', 'LoginService', 'ChefService', '_'];
 
-    function MenuCtrl($rootScope, $scope, $state, $ionicHistory, $ionicModal, LoginService, ChefService, CacheService, _) {
+    function MenuCtrl($rootScope, $scope, $state, $ionicHistory, $ionicModal, LoginService, ChefService, _) {
 
         var vm = this;
         vm.logout = logout;
@@ -49,11 +49,11 @@
 
         function init() {
             var user = LoginService.getUser();
-            vm.isUserLoggedIn = !!user;
-            vm.userFirstName = user ? user.first_name : '';
+            vm.isUserLoggedIn = user.isLoggedIn;
+            vm.userFirstName = user.first_name || '';
             vm.isChef = undefined;
             vm.selectedPath = null;
-            if (user) {
+            if (user.id) {
                 ChefService.getChefInfo(user.id)
                     .then(function() {
                         vm.isChef = true;
@@ -90,8 +90,8 @@
                 }
                 return;
             }
-            var validZipCode = CacheService.getCache('hcvalidzipcode'),
-                redirectPath = validZipCode ? 'app.buyer' : 'zipcode-validation';
+            var zipcode = LoginService.getUser().zipcode,
+                redirectPath = !!zipcode ? 'app.buyer' : 'zipcode-validation';
             if (!vm.isUserLoggedIn && path !== redirectPath) {
                 if (event) {
                     event.preventDefault();

--- a/app/scripts/settings.controller.js
+++ b/app/scripts/settings.controller.js
@@ -1,19 +1,19 @@
 (function() {
     'use strict';
-    
+
     angular
         .module('HomeCooked.controllers')
         .controller('SettingsCtrl', SettingsCtrl);
 
-    SettingsCtrl.$inject = ['$rootScope', '$scope', '$state', '$timeout', '$ionicPlatform', 
+    SettingsCtrl.$inject = ['$scope', '$state', '$timeout', '$ionicPlatform',
         '$ionicPopup', '$ionicLoading', '$ionicHistory', 'LoginService'];
-    
-    function SettingsCtrl($rootScope, $scope, $state, $timeout, $ionicPlatform, 
+
+    function SettingsCtrl($scope, $state, $timeout, $ionicPlatform,
         $ionicPopup, $ionicLoading, $ionicHistory, LoginService) {
 
         var vm = this;
         vm.onChange = onChange;
-        vm.onSave = onSave;        
+        vm.onSave = onSave;
         vm.openExternalLink = openExternalLink;
         vm.openRatingLink = openRatingLink;
         vm.confirmLogout = confirmLogout;
@@ -65,7 +65,7 @@
                         historyRoot: true,
                         disableAnimate: true
                     });
-                    $state.go('app.buyer');
+                    $state.go('zipcode-validation');
                 }
             });
         }

--- a/app/scripts/zipcoderestriction.controller.js
+++ b/app/scripts/zipcoderestriction.controller.js
@@ -85,10 +85,8 @@
                 //FAKE API CALL
                 $timeout(function() {
                     $ionicLoading.hide();
-                    //temporary code, all value starting by 94 are going to be valid
-                    //otherwise, it is not an available zip code
-                    var isAvailable = vm.zipcode.indexOf('94') === 0;
-
+                    var availableZipCodes = [94114, 94131, 94110, 94102, 94103, 95117];
+                    var isAvailable = availableZipCodes.indexOf(parseInt(vm.zipcode)) !== -1;
                     CacheService.setCache('hcvalidzipcode', isAvailable);
                     if (isAvailable) {
                         $ionicHistory.nextViewOptions({

--- a/app/scripts/zipcoderestriction.controller.js
+++ b/app/scripts/zipcoderestriction.controller.js
@@ -32,6 +32,12 @@
                 lng: coords.longitude,
                 zoom: 14
             };
+            vm.map.markers = {
+                marker: {
+                    lat: coords.latitude,
+                    lng: coords.longitude
+                }
+            };
         }
 
         function onLocationError(error) {
@@ -64,7 +70,8 @@
                     lat: 37.773204,
                     lng: -122.4213458,
                     zoom: 14
-                }
+                }, 
+                markers: {}
             };
         }
 

--- a/app/scripts/zipcoderestriction.controller.js
+++ b/app/scripts/zipcoderestriction.controller.js
@@ -5,13 +5,13 @@
         .module('HomeCooked.controllers')
         .controller('ZipCodeRestrictionCtrl', ZipCodeRestrictionCtrl);
 
-    ZipCodeRestrictionCtrl.$inject = ['$timeout', '$ionicHistory', '$state', '$ionicLoading', '$ionicPopup'];
+    ZipCodeRestrictionCtrl.$inject = ['$stateParams', '$timeout', '$ionicHistory', '$state', '$ionicLoading', '$ionicPopup'];
 
-    function ZipCodeRestrictionCtrl($timeout, $ionicHistory, $state, $ionicLoading, $ionicPopup) {
+    function ZipCodeRestrictionCtrl($stateParams, $timeout, $ionicHistory, $state, $ionicLoading, $ionicPopup) {
 
         var vm = this;
         vm.validZipCode = validZipCode;
-
+        vm.registerEmail = registerEmail;
 
         activate();
 
@@ -86,16 +86,40 @@
                 //FAKE API CALL
                 $timeout(function() {
                     $ionicLoading.hide();
-                    if (true) {
+                    //temporary code, all value starting by 94 are going to be valid
+                    //otherwise, it is not an available zip code
+                    var isAvailable = vm.zipcode.indexOf('94') === 0;
+                    if (isAvailable) {
                         $ionicHistory.nextViewOptions({
                           historyRoot: true
                         });
                         $state.go('app.buyer');
                     }
+                    else {
+                        $state.go('zipcode-unavailable', {
+                            zipcode: vm.zipcode
+                        });
+                    }
                 }, 1000);
             }
         }
 
+        function registerEmail() {
+            if (vm.email_address && $stateParams.zipcode) {
+                $ionicLoading.show({
+                    template: 'Registering...'
+                });
+                //FAKE API CALL PASSING THE EMAIL ADDRESS AND THE ZIP CODE
+                $timeout(function() {
+                    $ionicLoading.hide();
+                    vm.email_address = null;
+                    $ionicPopup.alert({
+                        title: 'Thank you for registering',
+                        template: 'We will let you know as soon as HomeCooked is available for your area.'
+                   });
+                }, 1000);
+            }
+        }
     }
 
 })();

--- a/app/scripts/zipcoderestriction.controller.js
+++ b/app/scripts/zipcoderestriction.controller.js
@@ -5,9 +5,9 @@
         .module('HomeCooked.controllers')
         .controller('ZipCodeRestrictionCtrl', ZipCodeRestrictionCtrl);
 
-    ZipCodeRestrictionCtrl.$inject = ['$stateParams', '$timeout', '$ionicHistory', '$state', '$ionicLoading', '$ionicPopup', 'CacheService'];
+    ZipCodeRestrictionCtrl.$inject = ['$stateParams', '$timeout', '$ionicHistory', '$state', '$ionicLoading', '$ionicPopup', 'LoginService'];
 
-    function ZipCodeRestrictionCtrl($stateParams, $timeout, $ionicHistory, $state, $ionicLoading, $ionicPopup, CacheService) {
+    function ZipCodeRestrictionCtrl($stateParams, $timeout, $ionicHistory, $state, $ionicLoading, $ionicPopup, LoginService) {
 
         var vm = this;
         vm.validZipCode = validZipCode;
@@ -87,7 +87,7 @@
                     $ionicLoading.hide();
                     var availableZipCodes = [94114, 94131, 94110, 94102, 94103, 95117];
                     var isAvailable = availableZipCodes.indexOf(parseInt(vm.zipcode)) !== -1;
-                    CacheService.setCache('hcvalidzipcode', isAvailable);
+                    LoginService.setUserZipCode(vm.zipcode);
                     if (isAvailable) {
                         $ionicHistory.nextViewOptions({
                           historyRoot: true

--- a/app/scripts/zipcoderestriction.controller.js
+++ b/app/scripts/zipcoderestriction.controller.js
@@ -9,7 +9,33 @@
 
     function ZipCodeRestrictionCtrl() {
 
-        // var vm = this;
+        var vm = this;
+
+        vm.map = {
+            defaults: {
+                zoomControl: false,
+                attributionControl: false,
+                doubleClickZoom: true,
+                scrollWheelZoom: true
+            },
+            tiles: {
+                url: 'https://mt{s}.googleapis.com/vt?x={x}&y={y}&z={z}&style=high_dpi&w=512',
+                options: {
+                    subdomains: [0, 1, 2, 3],
+                    detectRetina: true,
+                    tileSize: 512,
+                    minZoom: 2,
+                    maxZoom: 21,
+                    reuseTiles: true,
+                    noWrap: true
+                }
+            },
+            center: {
+                lat: 37.7685616,
+                lng: -122.4152349,
+                zoom: 14
+            }
+        };
 
     }
 

--- a/app/scripts/zipcoderestriction.controller.js
+++ b/app/scripts/zipcoderestriction.controller.js
@@ -114,7 +114,7 @@
                     vm.email_address = null;
                     $ionicPopup.alert({
                         title: 'Thank you for registering',
-                        template: 'We will let you know as soon as HomeCooked is available for your area.'
+                        template: 'Thank you, we will be in touch shortly.'
                    });
                 }, 1000);
             }

--- a/app/scripts/zipcoderestriction.controller.js
+++ b/app/scripts/zipcoderestriction.controller.js
@@ -5,11 +5,12 @@
         .module('HomeCooked.controllers')
         .controller('ZipCodeRestrictionCtrl', ZipCodeRestrictionCtrl);
 
-    ZipCodeRestrictionCtrl.$inject = [];
+    ZipCodeRestrictionCtrl.$inject = ['$timeout', '$ionicHistory', '$state', '$ionicLoading'];
 
-    function ZipCodeRestrictionCtrl() {
+    function ZipCodeRestrictionCtrl($timeout, $ionicHistory, $state, $ionicLoading) {
 
         var vm = this;
+        vm.validZipCode = validZipCode;
 
         vm.map = {
             defaults: {
@@ -38,6 +39,31 @@
                 zoom: 14
             }
         };
+
+        activate();
+
+
+        function activate() {
+
+        }
+
+        function validZipCode() {
+            if (vm.zipcode && parseInt(vm.zipcode) > 0) {
+                $ionicLoading.show({
+                    template: 'Checking...'
+                });
+                //FAKE API CALL
+                $timeout(function() {
+                    $ionicLoading.hide();
+                    if (true) {
+                        $ionicHistory.nextViewOptions({
+                          historyRoot: true
+                        });
+                        $state.go('app.buyer');
+                    }
+                }, 1000);
+            }
+        }
 
     }
 

--- a/app/scripts/zipcoderestriction.controller.js
+++ b/app/scripts/zipcoderestriction.controller.js
@@ -1,0 +1,16 @@
+(function() {
+    'use strict';
+
+    angular
+        .module('HomeCooked.controllers')
+        .controller('ZipCodeRestrictionCtrl', ZipCodeRestrictionCtrl);
+
+    ZipCodeRestrictionCtrl.$inject = [];
+
+    function ZipCodeRestrictionCtrl() {
+
+        // var vm = this;
+
+    }
+
+})();

--- a/app/scripts/zipcoderestriction.controller.js
+++ b/app/scripts/zipcoderestriction.controller.js
@@ -15,8 +15,10 @@
             defaults: {
                 zoomControl: false,
                 attributionControl: false,
-                doubleClickZoom: true,
-                scrollWheelZoom: true
+                doubleClickZoom: false,
+                scrollWheelZoom: false,
+                dragging: false,
+                touchZoom: false,
             },
             tiles: {
                 url: 'https://mt{s}.googleapis.com/vt?x={x}&y={y}&z={z}&style=high_dpi&w=512',
@@ -31,8 +33,8 @@
                 }
             },
             center: {
-                lat: 37.7685616,
-                lng: -122.4152349,
+                lat: 37.773204,
+                lng: -122.4213458,
                 zoom: 14
             }
         };

--- a/app/scripts/zipcoderestriction.controller.js
+++ b/app/scripts/zipcoderestriction.controller.js
@@ -5,9 +5,9 @@
         .module('HomeCooked.controllers')
         .controller('ZipCodeRestrictionCtrl', ZipCodeRestrictionCtrl);
 
-    ZipCodeRestrictionCtrl.$inject = ['$timeout', '$ionicHistory', '$state', '$ionicLoading'];
+    ZipCodeRestrictionCtrl.$inject = ['$timeout', '$ionicHistory', '$state', '$ionicLoading', '$ionicPopup'];
 
-    function ZipCodeRestrictionCtrl($timeout, $ionicHistory, $state, $ionicLoading) {
+    function ZipCodeRestrictionCtrl($timeout, $ionicHistory, $state, $ionicLoading, $ionicPopup) {
 
         var vm = this;
         vm.validZipCode = validZipCode;
@@ -40,8 +40,11 @@
             };
         }
 
-        function onLocationError(error) {
-            alert(error);
+        function onLocationError() {
+            $ionicPopup.alert({
+                title: 'Error',
+                template: 'Unable to retrieve your location'
+           });
         }
 
         function initMapProperties() {           

--- a/app/scripts/zipcoderestriction.controller.js
+++ b/app/scripts/zipcoderestriction.controller.js
@@ -12,39 +12,60 @@
         var vm = this;
         vm.validZipCode = validZipCode;
 
-        vm.map = {
-            defaults: {
-                zoomControl: false,
-                attributionControl: false,
-                doubleClickZoom: false,
-                scrollWheelZoom: false,
-                dragging: false,
-                touchZoom: false,
-            },
-            tiles: {
-                url: 'https://mt{s}.googleapis.com/vt?x={x}&y={y}&z={z}&style=high_dpi&w=512',
-                options: {
-                    subdomains: [0, 1, 2, 3],
-                    detectRetina: true,
-                    tileSize: 512,
-                    minZoom: 2,
-                    maxZoom: 21,
-                    reuseTiles: true,
-                    noWrap: true
-                }
-            },
-            center: {
-                lat: 37.773204,
-                lng: -122.4213458,
-                zoom: 14
-            }
-        };
 
         activate();
 
 
         function activate() {
+            if ($state.current.name === 'zipcode-validation') {
+                initMapProperties();
+                $timeout(function() {
+                    navigator.geolocation.getCurrentPosition(onLocationSuccess, onLocationError);
+                }, 500);
+            }
+        }
 
+        function onLocationSuccess(position) {
+            var coords = position.coords;
+            vm.map.center = {
+                lat: coords.latitude,
+                lng: coords.longitude,
+                zoom: 14
+            };
+        }
+
+        function onLocationError(error) {
+            alert(error);
+        }
+
+        function initMapProperties() {           
+            vm.map = {
+                defaults: {
+                    zoomControl: false,
+                    attributionControl: false,
+                    doubleClickZoom: false,
+                    scrollWheelZoom: false,
+                    dragging: false,
+                    touchZoom: false,
+                },
+                tiles: {
+                    url: 'https://mt{s}.googleapis.com/vt?x={x}&y={y}&z={z}&style=high_dpi&w=512',
+                    options: {
+                        subdomains: [0, 1, 2, 3],
+                        detectRetina: true,
+                        tileSize: 512,
+                        minZoom: 2,
+                        maxZoom: 21,
+                        reuseTiles: true,
+                        noWrap: true
+                    }
+                },
+                center: {
+                    lat: 37.773204,
+                    lng: -122.4213458,
+                    zoom: 14
+                }
+            };
         }
 
         function validZipCode() {

--- a/app/scripts/zipcoderestriction.controller.js
+++ b/app/scripts/zipcoderestriction.controller.js
@@ -87,8 +87,8 @@
                     $ionicLoading.hide();
                     var availableZipCodes = [94114, 94131, 94110, 94102, 94103, 95117];
                     var isAvailable = availableZipCodes.indexOf(parseInt(vm.zipcode)) !== -1;
-                    LoginService.setUserZipCode(vm.zipcode);
                     if (isAvailable) {
+                        LoginService.setUserZipCode(vm.zipcode);
                         $ionicHistory.nextViewOptions({
                           historyRoot: true
                         });

--- a/app/scripts/zipcoderestriction.controller.js
+++ b/app/scripts/zipcoderestriction.controller.js
@@ -5,16 +5,15 @@
         .module('HomeCooked.controllers')
         .controller('ZipCodeRestrictionCtrl', ZipCodeRestrictionCtrl);
 
-    ZipCodeRestrictionCtrl.$inject = ['$stateParams', '$timeout', '$ionicHistory', '$state', '$ionicLoading', '$ionicPopup'];
+    ZipCodeRestrictionCtrl.$inject = ['$stateParams', '$timeout', '$ionicHistory', '$state', '$ionicLoading', '$ionicPopup', 'CacheService'];
 
-    function ZipCodeRestrictionCtrl($stateParams, $timeout, $ionicHistory, $state, $ionicLoading, $ionicPopup) {
+    function ZipCodeRestrictionCtrl($stateParams, $timeout, $ionicHistory, $state, $ionicLoading, $ionicPopup, CacheService) {
 
         var vm = this;
         vm.validZipCode = validZipCode;
         vm.registerEmail = registerEmail;
 
         activate();
-
 
         function activate() {
             if ($state.current.name === 'zipcode-validation') {
@@ -47,7 +46,7 @@
            });
         }
 
-        function initMapProperties() {           
+        function initMapProperties() {
             vm.map = {
                 defaults: {
                     zoomControl: false,
@@ -73,7 +72,7 @@
                     lat: 37.773204,
                     lng: -122.4213458,
                     zoom: 14
-                }, 
+                },
                 markers: {}
             };
         }
@@ -89,6 +88,8 @@
                     //temporary code, all value starting by 94 are going to be valid
                     //otherwise, it is not an available zip code
                     var isAvailable = vm.zipcode.indexOf('94') === 0;
+
+                    CacheService.setCache('hcvalidzipcode', isAvailable);
                     if (isAvailable) {
                         $ionicHistory.nextViewOptions({
                           historyRoot: true

--- a/app/styles/_zipcode-restriction.scss
+++ b/app/styles/_zipcode-restriction.scss
@@ -7,7 +7,20 @@
         text-align: center;
         height: 100%;
 
+        .zipcode-map {
+            -webkit-flex-grow: 2;
+            background-color: #ccc;
+            position: relative;
+            .angular-leaflet-map {
+                width: 100%;
+                height:100%;
+                display:block;
+                position:absolute;
+            }
+        }
+
         .zipcode-form {
+            border-top: 1px solid #ccc;
             background-color: #efefef;
             padding: 40px 10px 10px;
 
@@ -15,6 +28,7 @@
                 margin: 0;
                 font-size: 125%;
                 color: #333;
+                font-weight: 400;
                 letter-spacing: 1px;
             }
             input {
@@ -38,6 +52,7 @@
 
             button {
                 font-size: 100%;
+                letter-spacing: 1px;
             }
         }
         

--- a/app/styles/_zipcode-restriction.scss
+++ b/app/styles/_zipcode-restriction.scss
@@ -27,7 +27,6 @@
             p {
                 margin: 0;
                 font-size: 125%;
-                color: #333;
                 font-weight: 400;
                 letter-spacing: 1px;
             }
@@ -56,6 +55,54 @@
             }
         }
         
+    }
+
+    .area-not-available {
+        text-align: center;
+        padding-top: 40px;
+
+        i {
+            font-size: 600%;
+        }
+        p.title {
+            font-weight: bold;
+            margin: 20px auto;
+            padding: 0 20px;
+            font-size: 120%;
+        }
+        p.text {
+            text-align: justify;
+            padding: 0 20px 20px;
+        }
+
+        div.email-form {
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            background-color: #efefef;
+            padding: 20px 10px 10px;
+            margin: 10px;
+            input {
+                padding: 0;
+                    width: 100%;
+                text-align: center;
+                font-size: 120%;
+                letter-spacing: 1px;
+                color: #777;
+                font-weight: bold;
+                border: 1px solid #ddd;
+                border-radius: 4px;
+                height: 42px;
+                line-height: 42px;
+                &::-webkit-input-placeholder {
+                    font-size: 90%;
+                    font-weight: normal;
+                }
+            }
+
+            a {
+                color: #777;
+            }
+        }
     }
 }
 

--- a/app/styles/_zipcode-restriction.scss
+++ b/app/styles/_zipcode-restriction.scss
@@ -1,0 +1,46 @@
+.zipcode-restriction-page { 
+
+    .container {
+        display: flex;
+        -webkit-flex-direction: column;
+        -webkit-justify-content: flex-end;
+        text-align: center;
+        height: 100%;
+
+        .zipcode-form {
+            background-color: #efefef;
+            padding: 40px 10px 10px;
+
+            p {
+                margin: 0;
+                font-size: 125%;
+                color: #333;
+                letter-spacing: 1px;
+            }
+            input {
+                width: 160px;
+                padding: 0;
+                margin: 1.5em auto;
+                text-align: center;
+                font-size: 150%;
+                letter-spacing: 1px;
+                color: #777;
+                font-weight: bold;
+                border: 1px solid #ddd;
+                border-radius: 4px;
+                height: 42px;
+                line-height: 42px;
+                &::-webkit-input-placeholder {
+                    font-size: 70%;
+                    font-weight: normal;
+                }
+            }
+
+            button {
+                font-size: 100%;
+            }
+        }
+        
+    }
+}
+

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -9,6 +9,7 @@
 body {
    font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif; 
    font-weight: 300;
+   color: #333;
 }
 
 

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -3,7 +3,13 @@
 @import 
     'mixins',
     'signup',
-    'settings';
+    'settings',
+    'zipcode-restriction';
+
+body {
+   font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif; 
+   font-weight: 300;
+}
 
 
 .hc-menu-item-selected {

--- a/app/templates/menu.html
+++ b/app/templates/menu.html
@@ -21,7 +21,7 @@
       </ion-toggle>
       <ion-list>
         <ion-item ng-repeat="link in vm.links" nav-clear menu-close ng-click="vm.go(link.path)"
-                  ng-class="{'hc-menu-item-selected' : link.path===vm.selectedPath}">
+                  ng-class="{'hc-menu-item-selected' : link.selected}">
           {{::link.name}}
         </ion-item>
       </ion-list>

--- a/app/templates/zipcode/form.html
+++ b/app/templates/zipcode/form.html
@@ -2,13 +2,13 @@
     <ion-content scroll="false">
         <div class="container">
             <div class="zipcode-map" data-tab-disable="true">
-                <leaflet id="meetupmap" defaults="vm.map.defaults" tiles="vm.map.tiles" center="vm.map.center"></leaflet>
+                <leaflet id="zipcodemap" defaults="vm.map.defaults" tiles="vm.map.tiles" center="vm.map.center"></leaflet>
             </div>
             <div class="zipcode-form">
                 <form ng-submit="vm.validZipCode()">
                     <p>PLEASE CONFIRM YOUR ZIP CODE</p>
                     <input type="tel" placeholder="ZIP Code" ng-model="vm.zipcode"/>
-                    <button class="button button-block button-dark">CHECK AVAILABILITY</button>
+                    <button class="button button-block button-dark">VIEW CHEFS IN YOUR AREA</button>
                 </form>
             </div>
         </div>

--- a/app/templates/zipcode/form.html
+++ b/app/templates/zipcode/form.html
@@ -1,0 +1,9 @@
+<ion-view class="signup-page">
+    <ion-content scroll="false">
+        <div class="container">
+            <div class="signup-btns">
+                
+            </div>
+        </div>
+    </ion-content>
+</ion-view>

--- a/app/templates/zipcode/form.html
+++ b/app/templates/zipcode/form.html
@@ -1,8 +1,11 @@
-<ion-view class="signup-page">
+<ion-view class="zipcode-restriction-page">
     <ion-content scroll="false">
         <div class="container">
-            <div class="signup-btns">
-                
+            <div class="map"></div>
+            <div class="zipcode-form">
+                <p>PLEASE CONFIRM YOUR ZIP CODE</p>
+                <input type="text" placeholder="ZIP Code" />
+                <button class="button button-block button-dark">CHECK AVAILABILITY FOR YOUR AREA</button>
             </div>
         </div>
     </ion-content>

--- a/app/templates/zipcode/form.html
+++ b/app/templates/zipcode/form.html
@@ -2,7 +2,7 @@
     <ion-content scroll="false">
         <div class="container">
             <div class="zipcode-map" data-tab-disable="true">
-                <leaflet id="zipcodemap" defaults="vm.map.defaults" tiles="vm.map.tiles" center="vm.map.center"></leaflet>
+                <leaflet id="zipcodemap" defaults="vm.map.defaults" tiles="vm.map.tiles" center="vm.map.center" markers="vm.map.markers"></leaflet>
             </div>
             <div class="zipcode-form">
                 <form ng-submit="vm.validZipCode()">

--- a/app/templates/zipcode/form.html
+++ b/app/templates/zipcode/form.html
@@ -5,9 +5,11 @@
                 <leaflet id="meetupmap" defaults="vm.map.defaults" tiles="vm.map.tiles" center="vm.map.center"></leaflet>
             </div>
             <div class="zipcode-form">
-                <p>PLEASE CONFIRM YOUR ZIP CODE</p>
-                <input type="text" placeholder="ZIP Code" />
-                <button class="button button-block button-dark">CHECK AVAILABILITY FOR YOUR AREA</button>
+                <form ng-submit="vm.validZipCode()">
+                    <p>PLEASE CONFIRM YOUR ZIP CODE</p>
+                    <input type="tel" placeholder="ZIP Code" ng-model="vm.zipcode"/>
+                    <button class="button button-block button-dark">CHECK AVAILABILITY</button>
+                </form>
             </div>
         </div>
     </ion-content>

--- a/app/templates/zipcode/form.html
+++ b/app/templates/zipcode/form.html
@@ -1,7 +1,9 @@
 <ion-view class="zipcode-restriction-page">
     <ion-content scroll="false">
         <div class="container">
-            <div class="map"></div>
+            <div class="zipcode-map" data-tab-disable="true">
+                <leaflet id="meetupmap" defaults="vm.map.defaults" tiles="vm.map.tiles" center="vm.map.center"></leaflet>
+            </div>
             <div class="zipcode-form">
                 <p>PLEASE CONFIRM YOUR ZIP CODE</p>
                 <input type="text" placeholder="ZIP Code" />

--- a/app/templates/zipcode/unavailable.html
+++ b/app/templates/zipcode/unavailable.html
@@ -1,0 +1,18 @@
+<ion-view class="zipcode-restriction-page">
+    <ion-content> 
+        <div class="area-not-available">
+            <i class="icon ion-android-sad"></i>
+
+            <p class="title">Sorry, HomeCooked is not available yet.</p>
+
+            <p class="text">It looks like your area is not supported yet. We are currently experiencing HomeCooked in San Francisco. Please, enter your email address to get notified as soon as HomeCooked got launched in your area.</p>
+            <div class="email-form">
+                <form ng-submit="vm.registerEmail()">
+                    <input type="email" placeholder="Email Address" ng-model="vm.email_address"/>
+                    <button class="button button-block button-dark">GET NOTIFIED</button>
+                    <a ui-sref="zipcode-validation">Change ZIP code</a>
+                </form>
+            </div>
+        </div>
+    </ion-content>
+</ion-view>

--- a/app/templates/zipcode/unavailable.html
+++ b/app/templates/zipcode/unavailable.html
@@ -1,11 +1,11 @@
 <ion-view class="zipcode-restriction-page">
-    <ion-content> 
+    <ion-content>
         <div class="area-not-available">
             <i class="icon ion-android-sad"></i>
 
             <p class="title">Sorry, your area is not yet supported.</p>
 
-            <p class="text">HomeCooked is growing fast. Please enter you email address and we will notify you when your area is available.</p>
+            <p class="text">HomeCooked is growing fast. Please enter your email address and we will notify you when your area is available.</p>
             <div class="email-form">
                 <form ng-submit="vm.registerEmail()">
                     <input type="email" placeholder="Email Address" ng-model="vm.email_address"/>

--- a/app/templates/zipcode/unavailable.html
+++ b/app/templates/zipcode/unavailable.html
@@ -3,9 +3,9 @@
         <div class="area-not-available">
             <i class="icon ion-android-sad"></i>
 
-            <p class="title">Sorry, HomeCooked is not available yet.</p>
+            <p class="title">Sorry, your area is not yet supported.</p>
 
-            <p class="text">It looks like your area is not supported yet. We are currently experiencing HomeCooked in San Francisco. Please, enter your email address to get notified as soon as HomeCooked got launched in your area.</p>
+            <p class="text">HomeCooked is growing fast. Please enter you email address and we will notify you when your area is available.</p>
             <div class="email-form">
                 <form ng-submit="vm.registerEmail()">
                     <input type="email" placeholder="Email Address" ng-model="vm.email_address"/>

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "ionic": "driftyco/ionic-bower#1.0.0",
     "lodash": "~3.6.0",
-    "angular-mocks": "~1.3.15"
+    "angular-mocks": "~1.3.15",
+    "angular-leaflet-directive": "~0.8.2"
   },
   "resolutions": {
     "angular": "1.3.15"


### PR DESCRIPTION
In this PR, I've added two pages to do the zip code restriction #18 

The first iteration contains:
- a map (using leaflet and google maps tiles) via bower, I retrieve the user location and center the map on the user if we got the location
- if the zipcode enters starts by ```94```, the zip code is considered like available (i.e. 94117 good, 54312 not good)
- if it is a valid zipcode, we redirect to the buyer page
- if it is an invalid zipcode, we redirect to a page where the user can enter an email address (I am not really happy with the content of the page, but we can improve it later. The text needs to be proofread and improved though)

What needs to be done in the future:
- after the location is retrieved, we need to call the back end to retrieve the zip code from the gps coordinates
- a call to the server with the zipcode entered to check the real availability
- a call to the server with the zipcode + email address to notify the user once the app is available in its area

So if you are guys are ok, I would like to start the review and merge the PR (once reviewed), we can improve the content and the API calls later.

@valdrinkoshi, @marcandreoli, feedback highly appreciated, thanks :)  

![screen shot 2015-06-09 at 9 44 36 pm](https://cloud.githubusercontent.com/assets/1867703/8075134/31aebc4a-0ef1-11e5-8893-0ecf883f1142.png)
![screen shot 2015-06-09 at 9 44 22 pm](https://cloud.githubusercontent.com/assets/1867703/8075135/356aa6b4-0ef1-11e5-85d1-2953485fde56.png)

